### PR TITLE
Allow to run unleash clients as context managers

### DIFF
--- a/UnleashClient/__init__.py
+++ b/UnleashClient/__init__.py
@@ -13,7 +13,6 @@ from UnleashClient.constants import METRIC_LAST_SENT_TIME, DISABLED_VARIATION
 from .utils import LOGGER
 from .deprecation_warnings import strategy_v2xx_deprecation_check
 
-
 # pylint: disable=dangerous-default-value
 class UnleashClient:
     """Client implementation."""
@@ -237,3 +236,11 @@ class UnleashClient:
             LOGGER.log(self.unleash_verbose_log_level, "Returning default flag/variation for feature: %s", feature_name)
             LOGGER.log(self.unleash_verbose_log_level, "Attempted to get feature flag/variation %s, but client wasn't initialized!", feature_name)
             return DISABLED_VARIATION
+
+    def __enter__(self) -> "UnleashClient":
+        self.initialize_client()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.destroy()
+        return False

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -253,6 +253,16 @@ def test_uc_is_enabled_error_states(unleash_client):
 
 
 @responses.activate
+def test_uc_context_manager(unleash_client_nodestroy):
+    responses.add(responses.POST, URL + REGISTER_URL, json={}, status=202)
+    responses.add(responses.GET, URL + FEATURES_URL, json=MOCK_FEATURE_RESPONSE, status=200)
+    responses.add(responses.POST, URL + METRICS_URL, json={}, status=202)
+
+    with unleash_client_nodestroy as unleash_client:
+        assert unleash_client.is_initialized
+
+
+@responses.activate
 def test_uc_not_initialized_isenabled():
     unleash_client = UnleashClient(URL, APP_NAME)
     assert not unleash_client.is_enabled("ThisFlagDoesn'tExist")


### PR DESCRIPTION
The

```
with UnleashClient(...) as client:
    client.is_enabled(...)
```

idiom is very pythonic. It reduces the code size over the current
explicit initialization and destruction and ensures the client will be
destroyed even if there are exceptions during its lifetime (i.e, the
user's program fails before destroying its client).
